### PR TITLE
Fix: Automatically accept Android SDK licenses in GitHub Actions work…

### DIFF
--- a/GameFileInspector/.github/workflows/android-release-apk.yml
+++ b/GameFileInspector/.github/workflows/android-release-apk.yml
@@ -32,6 +32,13 @@ jobs:
       # This action will automatically install the required SDK tools and platforms
       # based on the project's build.gradle files.
 
+    - name: Accept all Android SDK licenses
+      run: yes | ${{ env.ANDROID_SDK_ROOT }}/cmdline-tools/latest/bin/sdkmanager --licenses || true
+      # Using ANDROID_SDK_ROOT which is set by setup-android action.
+      # Using 'latest/bin/sdkmanager' for robustness.
+      # '|| true' is a fallback to prevent build failure if the command itself has an issue
+      # but licenses might already be accepted or not be the blocking issue.
+
     - name: 🎯 Cache Gradle dependencies
       uses: actions/cache@v4
       with:


### PR DESCRIPTION
…flow

This commit updates the GitHub Actions workflow (`GameFileInspector/.github/workflows/android-release-apk.yml`) to prevent builds from stalling due to unaccepted Android SDK licenses.

A new step has been added after the Android SDK setup:
- Name: "Accept all Android SDK licenses"
- Command: `yes | ${{ env.ANDROID_SDK_ROOT }}/cmdline-tools/latest/bin/sdkmanager --licenses || true`

This command pipes "yes" to any license agreement prompts issued by the Android SDK manager, ensuring that all necessary licenses are accepted non-interactively during the CI run. This addresses issues where the build would otherwise halt awaiting manual input.