### PR TITLE
Fix: Enable AndroidX and Jetifier in gradle.properties

### DIFF
--- a/GameFileInspector/gradle.properties
+++ b/GameFileInspector/gradle.properties
@@ -1,0 +1,6 @@
+# Gradle JVM Args (if needed, uncomment and adjust)
+# org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+
+# AndroidX flags
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
This commit addresses a build failure caused by missing AndroidX configuration. The error "Configuration ':app:releaseRuntimeClasspath' contains AndroidX dependencies but the 'android.useAndroidX' property is not enabled" was reported during the ':app:dataBindingMergeDependencyArtifactsRelease' task.

The following properties have been added to `GameFileInspector/gradle.properties`:
- `android.useAndroidX=true`
- `android.enableJetifier=true`

These settings enable the use of AndroidX libraries and allow the build system to automatically migrate legacy support library dependencies from third-party libraries to AndroidX, respectively. This should resolve the reported build issue and allow the build to proceed.